### PR TITLE
Upgrade Java from 17 to 21 in reusable workflows

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
 

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -36,10 +36,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
         gpg-passphrase: GPG_PASSPHRASE


### PR DESCRIPTION
Update setup-java action to use java-version 21 (Temurin) in both maven-build and maven-release reusable workflows to align with projects that have migrated to Java 21.